### PR TITLE
Backend: Test Hashing

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -1,4 +1,5 @@
 node_modules/
 development.yaml
 app.yaml
+coverage
 

--- a/backend/package.json
+++ b/backend/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "start": "node src/server.js",
     "dev": "set NODE_ENV=development&& nodemon src/server.js --ext js",
-    "prod": "set NODE_ENV=production&& node src/server.js"
+    "prod": "set NODE_ENV=production&& node src/server.js",
+    "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js --coverage"
   },
   "author": "Andreas N. Digernes & Einar Uvsløkk",
   "license": "ISC",

--- a/backend/test/DataSet/hashing_data_set.json
+++ b/backend/test/DataSet/hashing_data_set.json
@@ -1,0 +1,18 @@
+{
+  "1": {
+    "plain_text": "LcAOoS6h",
+    "hash": "$2b$10$HGImWpGHTqsCUW7QPqE.xOLknm/a.IqV7bC.35ybKUGqLj13e9xiO"
+  },
+  "2": {
+    "plain_text": "kEns4u9e4d",
+    "hash": "$2b$10$B8gT6xGCeuL5BEfxYG6Ha.sOwa6gRoJp8kMP3s/UXIOXAx3R8UyUy"
+  },
+  "3": {
+    "plain_text": "SnxTm4TTYBwl",
+    "hash": "$2b$10$xgAJ1O6WfiuzL7FnPFs.J.kwodNLA4QfJkOUv6Y.SBlIi7.fvgBUC"
+  },
+  "4": {
+    "plain_text": "9G9dlTd",
+    "hash": "$2b$10$l4z28p7fGSRENdb5JtKBdO8l00B2WisE6hR9mYSnMH6rMAoA.APo2"
+  }
+}

--- a/backend/test/UnitTest/Security/hashing.test.js
+++ b/backend/test/UnitTest/Security/hashing.test.js
@@ -1,0 +1,48 @@
+import data from '../../DataSet/hashing_data_set.json';
+import { config, hashPassword, comparePassword } from '../../../src/internal.js';
+
+let plainText;
+let hash;
+
+beforeAll(async () => {
+  plainText = data["1"].plain_text;
+  hash = data["1"].hash;
+});
+
+test("Hash password.", () => {
+  return hashPassword(plainText)
+  .then(result => {
+    const expectedResult = {
+      status: 200,
+      type: config.env.RESPONSE_TYPE.success,
+      data: { hashed_password: hash },
+    }
+
+    expect(result).not.toEqual(expectedResult);
+  });
+});
+
+test("Make hashing throw an error", () => {
+  return hashPassword(null)
+  .catch(error => expect(error.message).toMatch('data and salt arguments required'));
+});
+
+test("Compare password", () => {
+  return comparePassword(plainText, hash)
+  .then(result => {
+    const expectedResult = {
+      status: 200,
+      type: config.env.RESPONSE_TYPE.success,
+      data: { is_matching: true },
+    }
+
+    expect(result).toEqual(expectedResult);
+  });
+});
+
+test("Make compare password throw an error", () => {
+  return comparePassword(1, hash)
+  .catch(error => {
+    expect(error.message).toMatch("data and hash must be strings");
+  });
+});


### PR DESCRIPTION
Written tests for code in hashing.js. They test if a password is hashed and different from the original hash, hash password function handle errors, compare password function compares a plain text password with a hashed password correctly, and compare password function handles errors.

Created a data set used to test hashing.js. It contains a plain text password and its hashed version.

Added a test script to package.json. The scripts uses the --experimental-vm-modules flag to allow jest to process ES6 syntax, like for example import statements without throwing errors.
To run all tests use: npm test.
To run a tests for a single file use: npm test <name_of_file>

Added coverage folder to gitignore file.
Coverage folder is created by jest when tests are runned and contains test coverage for the project.