### PR TITLE
Backend: Fix Sign Out Bug

### DIFF
--- a/backend/src/API/GraphQL/Query/query.js
+++ b/backend/src/API/GraphQL/Query/query.js
@@ -156,7 +156,7 @@ const signOutQuery = {
   },
   async resolve(parent, args, context){
     try{
-      authenticateAccessToken(context);
+      await authenticateAccessToken(context);
       return deleteRefreshTokenFromDatabase(args.refresh_token);
     } catch(error){
       return error;


### PR DESCRIPTION
Missing await on sign out endpoint caused a bug when trying to sign out twice.

Closes #56