### PR TITLE
Backend: Fix Missing Import

### DIFF
--- a/backend/src/internal.js
+++ b/backend/src/internal.js
@@ -43,7 +43,6 @@ export * as FirebaseProvider from "./Database/Provider/firebase_provider.js";
 export * from "./Database/Query/query.js";
 
 export * from "./DataCollection/clickStream.js";
-export * from "./DataCollection/clickStreamItem.js";
 
 export * from "./ErrorHandler/error_handler.js";
 


### PR DESCRIPTION
The file clickStreamItem in src/DataCollection is no longer available from merge #102, and the file was therefore deleted.
This commit fixes a crash when starting server by removing the filepath for that file from internal.js.