### PR TITLE
Implement seamless access token renewal

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -38,6 +38,7 @@
     "i18n-js": "^3.8.0",
     "jest": "^26.6.3",
     "jest-expo": "^44.0.1",
+    "jwt-decode": "^3.1.2",
     "react": "17.0.1",
     "react-dom": "17.0.1",
     "react-native": "0.64.3",

--- a/frontend/src/services/api/authLink.js
+++ b/frontend/src/services/api/authLink.js
@@ -1,14 +1,49 @@
 import { setContext } from "@apollo/client/link/context";
+import { onError } from "@apollo/client/link/error";
 import * as Storage from "../storage";
+import { getNewToken, isTokenValid } from "./token";
 
-const authLink = setContext(async (_, { headers }) => {
-  const token = await Storage.getItem("accessToken");
+// Cached access token to avoid async calls for every request
+// This will be reset upon 401 server error's
+let cachedToken;
+
+const withToken = setContext(() => {
+  if (cachedToken) {
+    return { token: cachedToken };
+  }
+  return Storage.getItem("accessToken").then((accessToken) => {
+    cachedToken = accessToken;
+    return { token: cachedToken };
+  });
+});
+
+const withAuth = setContext(async (_, { headers, token }) => {
+  let accessToken = token;
+
+  if (!isTokenValid(accessToken)) {
+    accessToken = await getNewToken();
+    Storage.setItem("accessToken", accessToken);
+    cachedToken = accessToken;
+  }
+
   return {
     headers: {
       ...headers,
-      authorization: token ? `Bearer ${token}` : "",
+      authorization: accessToken ? `Bearer ${accessToken}` : "",
     },
   };
 });
+
+const resetToken = onError(({ networkError }) => {
+  if (
+    networkError &&
+    networkError.name === "ServerError" &&
+    networkError.statusCode === 401
+  ) {
+    cachedToken = null;
+  }
+});
+
+const authLink = withToken.concat(withAuth).concat(resetToken);
 
 export default authLink;

--- a/frontend/src/services/api/errorLink.js
+++ b/frontend/src/services/api/errorLink.js
@@ -1,55 +1,11 @@
-import { fromPromise } from "@apollo/client";
 import { onError } from "@apollo/client/link/error";
-import fetch from "cross-fetch";
-import Constants from "expo-constants";
-import * as Storage from "../storage";
 
-async function fetchNewToken() {
-  const { apiEndpoint } = Constants.manifest.extra;
-  const refreshToken = await Storage.getItem("refreshToken");
-  return fetch(apiEndpoint, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({
-      query: `
-        query GetToken($refreshToken: String!) {
-          getNewToken(refreshToken: $refreshToken) {
-            accessToken
-          }
-        }
-      `,
-      variables: { refreshToken },
-    }),
-  });
-}
-
-const errorLink = onError(
-  ({ graphQLErrors, networkError, operation, forward }) => {
-    if (graphQLErrors) {
-      // eslint-disable-next-line consistent-return
-      graphQLErrors.forEach((error) => {
-        if (error.extensions?.code === "UNAUTHENTICATED") {
-          return fromPromise(fetchNewToken())
-            .filter((value) => Boolean(value))
-            .flatMap((accessToken) => {
-              const { headers } = operation.getContext();
-              operation.setContext({
-                headers: {
-                  ...headers,
-                  authorization: `Bearer ${accessToken}`,
-                },
-              });
-              return forward(operation);
-            });
-        }
-      });
-    }
-    // eslint-disable-next-line no-undef
-    if (__DEV__) {
-      console.debug("GraphQL Errors:", graphQLErrors);
-      console.debug("Network Error:", networkError);
-    }
+const errorLink = onError(({ graphQLErrors, networkError }) => {
+  // eslint-disable-next-line no-undef
+  if (__DEV__) {
+    console.debug("GraphQL Errors:", graphQLErrors);
+    console.debug("Network Error:", networkError);
   }
-);
+});
 
 export default errorLink;

--- a/frontend/src/services/api/token.js
+++ b/frontend/src/services/api/token.js
@@ -1,0 +1,43 @@
+import fetch from "cross-fetch";
+import Constants from "expo-constants";
+import jwtDecode from "jwt-decode";
+import * as Storage from "../storage";
+
+export function isTokenValid(token) {
+  let valid = true;
+  try {
+    const decoded = jwtDecode(token);
+    const currentTime = Date.now().valueOf() / 1000;
+    if (decoded.exp < currentTime) {
+      valid = false;
+    }
+  } catch (error) {
+    console.error("Error decoding access token:", error);
+    valid = false;
+  }
+  return valid;
+}
+
+export async function getNewToken() {
+  const { apiEndpoint } = Constants.manifest.extra;
+  const refreshToken = await Storage.getItem("refreshToken");
+  const token = await fetch(apiEndpoint, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      query: `
+        query getNewToken($refreshToken: String!) {
+          getNewToken(refreshToken: $refreshToken) {
+            accessToken
+          }
+        }
+      `,
+      variables: { refreshToken },
+    }),
+  })
+    .then((response) => response.json())
+    .then(({ data }) => {
+      return data?.getNewToken.accessToken;
+    });
+  return token;
+}

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -5497,6 +5497,11 @@ jsonify@~0.0.0:
     array-includes "^3.1.3"
     object.assign "^4.1.2"
 
+jwt-decode@^3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/jwt-decode/-/jwt-decode-3.1.2.tgz#3fb319f3675a2df0c2895c8f5e9fa4b67b04ed59"
+  integrity sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A==
+
 kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.2.0:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-3.2.2.tgz#31ea21a734bab9bbb0f32466d893aea51e4a3c64"


### PR DESCRIPTION
Instead of waiting for UNAUTHENTICATED errors before requesting a new
access token, we now check the expiration time and request a new token
beforehand if it has expired.