### PR TITLE
Backend: Swap Permission Logs Out Users, Feedback

### DIFF
--- a/backend/src/API/GraphQL/Query/subscriptions.js
+++ b/backend/src/API/GraphQL/Query/subscriptions.js
@@ -5,6 +5,7 @@ import config from "../../../Config/config.js";
 
 import {
   LeaderboardModel,
+  NormalResponseModel,
   UserModel,
   SwapPermissionPayload,
   pubsub,
@@ -48,9 +49,39 @@ const subscribeLeaderboard = {
   },
 };
 
-const subscribeSwappedPermission = {
+const subscribeUpdatePermission = {
   type: SwapPermissionPayload,
-  subscribe: () => pubsub.asyncIterator("SwapPermission"),
+  args: { subscribeToken: { type: GraphQLString } },
+  subscribe: withFilter(
+    () => pubsub.asyncIterator("UpdatePermission"),
+    (_, variables) => {
+      const verifiedUser = jwt.verify(
+        variables.subscribeToken,
+        config.secret.subscribeToken
+      );
+
+      return verifiedUser.id === variables.id;
+    }
+  ),
+  resolve: (payload) => {
+    return payload;
+  },
+};
+
+const subscribeSwappedPermission = {
+  type: NormalResponseModel,
+  args: { subscribeToken: { type: GraphQLString } },
+  subscribe: withFilter(
+    () => pubsub.asyncIterator("SwapPermission"),
+    (_, variables) => {
+      const verifiedUser = jwt.verify(
+        variables.subscribeToken,
+        config.secret.subscribeToken
+      );
+
+      return verifiedUser != null && verifiedUser === Object(verifiedUser);
+    }
+  ),
   resolve: (payload) => {
     return payload;
   },
@@ -59,5 +90,6 @@ const subscribeSwappedPermission = {
 export {
   subscribeLeaderboard,
   subscribeSwappedPermission,
+  subscribeUpdatePermission,
   subscribeUpdatedUser,
 };


### PR DESCRIPTION
When an admin trigger a swap permission of users, the users are logged out and informed of the event.

Added new subscribe function for updating a singel user's permission.

Closes #158