### PR TITLE
Backend: Support For Project Info

### DIFF
--- a/backend/src/API/GraphQL/Model/model.js
+++ b/backend/src/API/GraphQL/Model/model.js
@@ -1,4 +1,10 @@
-import { GraphQLObjectType, GraphQLString, GraphQLInt } from "graphql";
+import {
+  GraphQLObjectType,
+  GraphQLString,
+  GraphQLInt,
+  GraphQLInputObjectType,
+  GraphQLList,
+} from "graphql";
 
 const ResponseModel = {
   message: { type: GraphQLString },
@@ -13,4 +19,37 @@ const NormalResponseModel = new GraphQLObjectType({
   }),
 });
 
-export { NormalResponseModel, ResponseModel };
+const ContactInfo = {
+  name: { type: GraphQLString },
+  role: { type: GraphQLString },
+  phone: { type: GraphQLString },
+  email: { type: GraphQLString },
+};
+
+const ContactsInfoInputModel = new GraphQLInputObjectType({
+  name: "ContactsInfoInputModel",
+  fields: () => ({
+    ...ContactInfo,
+  }),
+});
+
+const ContactsInfoModel = new GraphQLObjectType({
+  name: "ContactsInfoModel",
+  fields: () => ({
+    ...ContactInfo,
+  }),
+});
+
+const ProjectInfoModel = new GraphQLObjectType({
+  name: "ProjectInfoModel",
+  fields: () => ({
+    contacts: { type: new GraphQLList(ContactsInfoModel) },
+  }),
+});
+
+export {
+  ContactsInfoInputModel,
+  NormalResponseModel,
+  ProjectInfoModel,
+  ResponseModel,
+};

--- a/backend/src/API/GraphQL/Query/projectInfoQuery.js
+++ b/backend/src/API/GraphQL/Query/projectInfoQuery.js
@@ -1,0 +1,36 @@
+import { GraphQLList } from "graphql";
+import {
+  ContactsInfoInputModel,
+  ProjectInfoModel,
+} from "../../../internal.js";
+import { assertIsAdmin, assertIsAuthenticated } from "../assert.js";
+
+// Root Queries - Used to retrieve data with GET-Requests
+
+const projectInfoQuery = {
+  type: ProjectInfoModel,
+  args: {},
+  async resolve(_, __, { user, providers }) {
+    assertIsAuthenticated(user);
+    const response = await providers.projectInfo.getAll();
+    return response[0];
+  },
+};
+
+// Mutation Queries - Used to update or delete data with PUT- and DELETE-requests
+
+const createProjectInfoQuery = {
+  type: ProjectInfoModel,
+  args: {
+    contacts: {
+      type: new GraphQLList(ContactsInfoInputModel),
+    },
+  },
+  async resolve(_, args, { user, providers }) {
+    assertIsAuthenticated(user);
+    assertIsAdmin(user);
+    return providers.projectInfo.add(args);
+  },
+};
+
+export { createProjectInfoQuery, projectInfoQuery };

--- a/backend/src/API/GraphQL/route.js
+++ b/backend/src/API/GraphQL/route.js
@@ -7,6 +7,7 @@ import {
   createAchievementQuery,
   createCategoryQuery,
   createChallengeQuery,
+  createProjectInfoQuery,
   deleteUserChallengeQuery,
   changePasswordQuery,
   getAllAchievementsQuery,
@@ -18,6 +19,7 @@ import {
   createUserQuery,
   deleteUserQuery,
   updateUserQuery,
+  projectInfoQuery,
   signInQuery,
   signOutQuery,
   verifyUsernameQuery,
@@ -45,6 +47,7 @@ const ROOTQUERY = new GraphQLObjectType({
     users: getAllUsersQuery,
     leaderboard: getLeaderboardQuery,
     accessToken: authRefreshTokenQuery,
+    projectInfo: projectInfoQuery,
     permissions: getPermissionsQuery,
     userProfile: getUserProfile,
     verifyToken: authAccessTokenQuery,
@@ -55,6 +58,7 @@ const ROOTQUERY = new GraphQLObjectType({
 const MUTATION = new GraphQLObjectType({
   name: "Mutation",
   fields: {
+    addProjectInfo: createProjectInfoQuery,
     addUserChallenge: addUserChallengeQuery,
     activateAccount: activateAccountQuery,
     changePassword: changePasswordQuery,

--- a/backend/src/Database/firestore.js
+++ b/backend/src/Database/firestore.js
@@ -12,6 +12,7 @@ export const providers = {
   categories: new FirestoreProvider(firestore, "Category"),
   challenges: new FirestoreProvider(firestore, "Challenge"),
   clickStreams: new FirestoreProvider(firestore, "ClickStream"),
+  projectInfo: new FirestoreProvider(firestore, "ProjectInfo"),
   refreshTokens: new FirestoreProvider(firestore, "RefreshToken"),
   subscribeTokens: new FirestoreProvider(firestore, "SubscribeToken"),
   users: new FirestoreProvider(firestore, "User"),

--- a/backend/src/internal.js
+++ b/backend/src/internal.js
@@ -10,6 +10,7 @@ export * from "./API/GraphQL/Query/categoryQuery.js";
 export * from "./API/GraphQL/Query/challengeQuery.js";
 export * from "./API/GraphQL/Query/clickStreamQuery.js";
 export * from "./API/GraphQL/Query/leaderboardQuery.js";
+export * from "./API/GraphQL/Query/projectInfoQuery.js";
 export * from "./API/GraphQL/Query/subscriptions.js";
 export * from "./API/GraphQL/Query/userQuery.js";
 export * from "./API/GraphQL/Query/Util/utility.js";


### PR DESCRIPTION
Added queries for GraphQL to create and retrieve project info about the experiment.

Implemented a project info model returning the contact information for the researchers.

Added a addProjectInfo and projectInfo Endpoint to graphQL.

Added the projectInfo query to internal.js for export.

closes #165 