### PR TITLE
Remove hardcoded locale setting

### DIFF
--- a/frontend/src/shared/i18n/index.js
+++ b/frontend/src/shared/i18n/index.js
@@ -9,7 +9,8 @@ i18n.translations = {
   nb,
 };
 
-i18n.locale = "nb" || Localization.locale;
+i18n.defaultLocale = "nb";
+i18n.locale = Localization.locale;
 i18n.fallbacks = true;
 
 export const { t } = i18n;


### PR DESCRIPTION
Sets the default locale to Norwegian Bokmål and tries to load the
current locale on the device.