### PR TITLE
Backend: Updated Smile-O-Meter Model

### DIFF
--- a/backend/src/API/GraphQL/Model/dataCollectionModel.js
+++ b/backend/src/API/GraphQL/Model/dataCollectionModel.js
@@ -4,7 +4,7 @@ import {
   GraphQLString,
   GraphQLList,
   GraphQLBoolean,
-  GraphQLEnumType,
+  GraphQLInt,
 } from "graphql";
 
 const deviceInfo = {
@@ -85,21 +85,10 @@ export const ClickStreamType = new GraphQLObjectType({
   }),
 });
 
-const LikertScale = new GraphQLEnumType({
-  name: "LikertScale",
-  values: {
-    stronglyDisagree: { value: -2 },
-    disagree: { value: -1 },
-    neutral: { value: 0 },
-    agree: { value: 1 },
-    stronglyAgree: { value: 2 },
-  },
-});
-
 export const SmileOMeterInput = new GraphQLInputObjectType({
   name: "SmileOMeterInput",
   fields: () => ({
     challengeID: { type: GraphQLString },
-    value: { type: LikertScale },
+    value: { type: GraphQLInt },
   }),
 });

--- a/backend/src/API/GraphQL/Query/smileOMeterQuery.js
+++ b/backend/src/API/GraphQL/Query/smileOMeterQuery.js
@@ -14,6 +14,12 @@ const logSmileOMeterQuery = {
       throw new UserInputError("Challenge does not exist.");
     }
 
+    if (value < -2 || value > 2) {
+      throw new UserInputError(
+        "Value from evaluation must be an integer from -2 to 2."
+      );
+    }
+
     let data = {};
     const smileOMeterData = await providers.smileOMeters.getByID(challengeID);
     if (smileOMeterData) {


### PR DESCRIPTION
The input for smile-o-meter is now an integer instead of a Likert Scale enum, as frontend maps smileys to integers and avoids less changes in implementation.

Query now checks if value of input is from -2 to 2.
Support of other Likert Scale implementations requires the value check to change.