### PR TITLE
Fix error checking for undefined JEST_WORKER_ID

### DIFF
--- a/frontend/src/services/sentry/index.js
+++ b/frontend/src/services/sentry/index.js
@@ -8,9 +8,11 @@ const { sentryDSN, enableSentry } = Constants.manifest.extra;
 // When testing Sentry is initialized with transport from sentry-testkit
 // See: https://github.com/getsentry/sentry-react-native/issues/1611
 // See: https://wix.github.io/sentry-testkit/#/getting-started/?id=working-with-jest
-const isJestTest = process.env.JEST_WORKER_ID !== "undefined";
+const isTesting =
+  process.env.JEST_WORKER_ID !== undefined ||
+  process.env.NODE_ENV === "testing";
 
-if (!isJestTest && enableSentry) {
+if (!isTesting && enableSentry) {
   Sentry.init({
     dsn: sentryDSN,
     enableInExpoDevelopment: true,


### PR DESCRIPTION
The environment variable JEST_WORKER_ID was incorrectly checked against
the string "undefined" instead of the type undefined. This also expands
the test check against the NODE_ENV variable, renaming the variable from
isJestTest -> isTesting.