### PR TITLE
Fix error trying to trim null value

### DIFF
--- a/backend/src/BusinessLogic/UserTracker/userReflection.js
+++ b/backend/src/BusinessLogic/UserTracker/userReflection.js
@@ -51,7 +51,13 @@ function vote(userReflection) {
 function isCompleted(userReflection) {
   const functionKey = "isCompleted";
   const code = () => {
-    return userReflection.dateCompleted.trim().length >= 0;
+    const { dateCompleted } = userReflection;
+    if (!dateCompleted) {
+      throw new UserInputError("Invalid timestamp for dateCompleted", {
+        dateCompleted,
+      });
+    }
+    return dateCompleted.trim().length >= 0;
   };
 
   return createObjectTemplate(functionKey, code);


### PR DESCRIPTION
The error happens when frontend reloads on the Completed screen tries to
add a userChallenge with dateCompleted set to null. It is rather an edge
case that most likely will never happen in prod, but never the less an
extra check is added and a proper API error is thrown when the
dateCompleted value is null.